### PR TITLE
WIP Isar image xen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,38 @@ MAINTAINER piotr.krol@3mdeb.com
 
 ENV http_proxy ${http_proxy}
 
+# Update the package repository
+RUN apt-get update && apt-get upgrade -y && apt-get install -y locales
+
+# Configure locales
+# noninteractive installation using debconf-set-selections does not seem
+# to work due to a bug in Debian glibc:
+# https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1598326
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 RUN \
-    useradd -p locked -m isar && \
     apt-get -qq update && \
     apt-get -qqy install \
-        dosfstools \
-        git \
+        ccache \
+        binfmt-support \
         debootstrap \
+        dosfstools \
         dpkg-dev \
+        git \
         parted \
         python3 \
         qemu \
         qemu-user-static \
-        binfmt-support \
-        sudo \
         reprepro \
+        sudo \
+        vim \
     && apt-get clean
 
 ENV PATH="/usr/lib/ccache:${PATH}"
-RUN mkdir /home/isar/.ccache && \
-    chown isar:isar /home/isar/.ccache
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:stretch-backports
+MAINTAINER piotr.krol@3mdeb.com
+
+ENV http_proxy ${http_proxy}
+
+RUN \
+    useradd -p locked -m isar && \
+    apt-get -qq update && \
+    apt-get -qqy install \
+        dosfstools \
+        git \
+        debootstrap \
+        dpkg-dev \
+        parted \
+        python3 \
+        qemu \
+        qemu-user-static \
+        binfmt-support \
+        sudo \
+        reprepro \
+    && apt-get clean
+
+ENV PATH="/usr/lib/ccache:${PATH}"
+RUN mkdir /home/isar/.ccache && \
+    chown isar:isar /home/isar/.ccache
+
+

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+
+docker run --privileged -v $PWD/../isar-build:/root/build -v $PWD:/root/isar -ti 3mdeb/isar

--- a/meta-isar/conf/distro/debian-buster.conf
+++ b/meta-isar/conf/distro/debian-buster.conf
@@ -9,4 +9,6 @@ DISTRO_KERNELS ?= "4kc-malta 5kc-malta 686 686-pae amd64 arm64 armmp \
 
 IMAGE_PREINSTALL += "init"
 
+KERNEL_NAME = "mainline"
+
 WIC_IMAGER_INSTALL += "python3-distutils"

--- a/meta-isar/recipes-core/images/isar-image-xen.bb
+++ b/meta-isar/recipes-core/images/isar-image-xen.bb
@@ -1,0 +1,7 @@
+require isar-image-base.bb
+
+IMAGER_INSTALL_append = " \
+    tpm2-tools \
+    xen-system-amd64 \
+    xen-tools \
+"

--- a/meta-isar/recipes-kernel/linux/linux-mainline_4.14.78.bb
+++ b/meta-isar/recipes-kernel/linux/linux-mainline_4.14.78.bb
@@ -10,7 +10,9 @@ require recipes-kernel/linux/linux-custom.inc
 SRC_URI += " \
     https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz \
     file://x86_64_defconfig"
-SRC_URI[sha256sum] = "866a94c1c38d923ae18e74b683d7a8a79b674ebdfe7f40f1a3be9a27d39fe354"
+
+SRC_URI[md5sum] = "23de7a544b95ec07f281be8b67223401"
+SRC_URI[sha256sum] = "f4da4dc0f079e420e1c1b8c71312eaa5415b08be847aa224a61d8af6a6e74c6c"
 
 S = "${WORKDIR}/linux-${PV}"
 


### PR DESCRIPTION
@pietrushnic 
Use ` bitbake multiconfig:qemuamd64-buster:isar-image-xen` to build buster rootfs from debian binary packages with mainline kernel (build from source)
